### PR TITLE
[BC] Add container registries on-demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ $ helm upgrade registry-secret-manager --namespace registry-secret-manager --val
 - [x] Reconcile ServiceAccounts (create Secrets and inject its name in `ImagePullSecrets`)
 - [x] Reconcile Secrets (renew ECR tokens every 3 hours)
 - [ ] Optimize ECR token usage (now each request/reconcile performs a new login)
-- [ ] Make DockerHub and ECR registries optional
+- [x] Make DockerHub and ECR registries optional
 - [ ] Use the same logging client for Controller-Runtime, Kubernetes Client, Webhook and Reconcilers
 - [ ] Make the Helm Chart available somewhere

--- a/pkg/registry/docker_hub.go
+++ b/pkg/registry/docker_hub.go
@@ -5,6 +5,8 @@ import (
 	"os"
 )
 
+const DockerHubName = "docker-hub"
+
 type DockerHub struct {
 }
 

--- a/pkg/registry/ecr.go
+++ b/pkg/registry/ecr.go
@@ -12,6 +12,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecr"
 )
 
+const EcrName = "ecr"
+
 type ECR struct {
 }
 


### PR DESCRIPTION
A new flag has been introduced that references which registries must be loaded.
As a DX improvement, the list of available registries has been centralized and
used all over the application.